### PR TITLE
fix launch timezone

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "1.0.0",
   "contributors": [
     "Maciek Pekala <maciek@pleo.io>",
-    "Peter Scott <peter@pleo.io>"
+    "Peter Scott <peter@pleo.io>",
+    "Lubos Tomandl <lutomandl@gmail.com"
   ],
   "license": "MIT",
   "private": true,
@@ -12,6 +13,7 @@
     "@emotion/core": "^10.0.35",
     "@emotion/styled": "^10.0.27",
     "emotion-theming": "^10.0.27",
+    "moment": "^2.29.1",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-feather": "^2.0.8",

--- a/src/components/launch.js
+++ b/src/components/launch.js
@@ -19,10 +19,11 @@ import {
   Stack,
   AspectRatioBox,
   StatGroup,
+  Tooltip
 } from "@chakra-ui/core";
 
 import { useSpaceX } from "../utils/use-space-x";
-import { formatDateTime } from "../utils/format-date";
+import { formatDateTime, formatDateTimeLocal } from "../utils/format-date";
 import Error from "./error";
 import Breadcrumbs from "./breadcrumbs";
 
@@ -123,11 +124,13 @@ function TimeAndLocation({ launch }) {
             Launch Date
           </Box>
         </StatLabel>
-        <StatNumber fontSize={["md", "xl"]}>
-          {formatDateTime(launch.launch_date_local)}
-        </StatNumber>
+        <Tooltip label={formatDateTimeLocal(launch.launch_date_local)} fontSize="xl" placement='top-start' openDelay={1000} bg="gray.300" color="black" shouldWrapChildren>
+          <StatNumber fontSize={["md", "xl"]}>
+            {formatDateTime(launch.launch_date_local)}
+          </StatNumber>
+        </Tooltip>
         <StatHelpText>{timeAgo(launch.launch_date_utc)}</StatHelpText>
-      </Stat>
+      </Stat> 
       <Stat>
         <StatLabel display="flex">
           <Box as={MapPin} width="1em" />{" "}

--- a/src/utils/format-date.js
+++ b/src/utils/format-date.js
@@ -1,3 +1,5 @@
+import moment from 'moment';
+
 export function formatDate(timestamp) {
   return new Intl.DateTimeFormat("en-US", {
     weekday: "long",
@@ -8,13 +10,9 @@ export function formatDate(timestamp) {
 }
 
 export function formatDateTime(timestamp) {
-  return new Intl.DateTimeFormat("en-US", {
-    year: "numeric",
-    month: "long",
-    day: "numeric",
-    hour: "numeric",
-    minute: "numeric",
-    second: "numeric",
-    timeZoneName: "short",
-  }).format(new Date(timestamp));
+  return moment.parseZone(timestamp).format('MMMM D, YYYY, H:mm:ss A [GMT] Z')
+}
+
+export function formatDateTimeLocal(timestamp) {
+  return moment(timestamp).format('MMMM D, YYYY, H:mm:ss A [GMT] Z')
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6901,6 +6901,11 @@ mkdirp@^0.5.5:
   dependencies:
     minimist "^1.2.5"
 
+moment@^2.29.1:
+  version "2.29.1"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.1.tgz#b2be769fa31940be9eeea6469c075e35006fa3d3"
+  integrity sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==
+
 move-concurrently@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/move-concurrently/-/move-concurrently-1.0.1.tgz#be2c005fda32e0b29af1f05d7c4b33214c701f92"


### PR DESCRIPTION
Fixed by using the `moment` library, because `new Date()` always transfers the time to the local timezone. `Intl.DateTimeFormat` can move the time to any selected timezone, but we don't know the timezone from the API, only the offset. 
On the other hand, the offset isn't shown very nicely (in the `+/- HH:mm` format), so this could use some more work to make the offset look more human-friendly.